### PR TITLE
Mudança na forma de parar o player

### DIFF
--- a/Escor/Assets/Escor/Player/Movement.cs
+++ b/Escor/Assets/Escor/Player/Movement.cs
@@ -170,20 +170,21 @@ public class Movement : MonoBehaviour {
             rb.velocity = new Vector2(0, rb.velocity.y); // impedir que o player fique deslisando
 
         if (LevelManager.levelstatus == LevelManager.LevelStatus.Game)
-        {
             Move();
+    }
+
+    void Update()
+    {
+        canMove = keepingMeStopped == 0 && !ropeControll.attached && !defendendo; // [Jessé]
+
+        if (LevelManager.levelstatus == LevelManager.LevelStatus.Game)
+        {
+            // Move();
             Jump();
             Defense();
             // SlowMotion();
             Stun();
         }
-
-        
-    }
-
-    void Update()
-    {
-        canMove = !(keepingMeStopped > 0 || ropeControll.attached || defendendo); // [Jessé]
 
         animator.SetFloat("VelocidadeY", rb.velocity.y);
 

--- a/Escor/Assets/Escor/Scenes/GameLevel.unity
+++ b/Escor/Assets/Escor/Scenes/GameLevel.unity
@@ -1610,9 +1610,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   control: {fileID: 140349217}
   levelsAvaibles:
+  - {fileID: 7248150087756879033, guid: 5897f0cab24a03c4aa647e0a167dde8d, type: 3}
   - {fileID: 3918995391385978380, guid: ecb353e8bfdc9ca40bbb36d6676f7d9f, type: 3}
   - {fileID: 2076049616461170651, guid: bfd4d4165a1c2d240a117c135b4d08c9, type: 3}
-  - {fileID: 7248150087756879033, guid: 5897f0cab24a03c4aa647e0a167dde8d, type: 3}
   levelInformation: {fileID: 0}
   characterPrefab: {fileID: 7302654321608639650, guid: 99624e07b8ae0aa4a9f8fda63f6fbe3b, type: 3}
   cam: {fileID: 11747968}

--- a/Escor/Assets/Jessé/Scripts/VcamFocusObject.cs
+++ b/Escor/Assets/Jessé/Scripts/VcamFocusObject.cs
@@ -87,6 +87,9 @@ public class VcamFocusObject : MonoBehaviour
 
 
         // finish                          = false;
+        if(focusing)
+            return;
+            
         allTargets                      = targets;
         focusing                        = true;
         keepFocusingTarget              = false;
@@ -178,13 +181,13 @@ public class VcamFocusObject : MonoBehaviour
 
         virtualCam.Follow = virtualCamTargetBackup; // reseta a camera para o alvo inicial
         // Movement.canMove  = true;
-        focusing          = false;
 
         if(stopPlayer)
             Movement.StopKeepPlayerStopped(); // faz o player se mover
 
         if(stopJavali)
             JavalisManager.instance.StopMovementOfJavalis(false);
+        focusing          = false;
     }
 
 

--- a/Escor/UserSettings/EditorUserSettings.asset
+++ b/Escor/UserSettings/EditorUserSettings.asset
@@ -12,28 +12,28 @@ EditorUserSettings:
       value: 224247031146467e1e0d03305f105c1518120b651c3a293c222e127df7ee3d2cfb
       flags: 0
     RecentlyUsedScenePath-2:
-      value: 224247031146467e1e0d03305f105c1518120b650d2a2322393c0f32cbee3d3bebe63aa7f234362820
-      flags: 0
-    RecentlyUsedScenePath-3:
       value: 224247031146467e1e0d03305f105c1518120b65002d303521164f7df7ee3d2cfb
       flags: 0
-    RecentlyUsedScenePath-4:
+    RecentlyUsedScenePath-3:
       value: 224247031146467e1e0d03305f105c1518120b651f2d2a352e3d3136f4e53876f7e93ffdfe
       flags: 0
-    RecentlyUsedScenePath-5:
+    RecentlyUsedScenePath-4:
       value: 224247031146467e1e0d03305f105c1518120b65002727340a281036d1e33136e7a923e7ee2e26
       flags: 0
-    RecentlyUsedScenePath-6:
+    RecentlyUsedScenePath-5:
       value: 224247031146467e1e0d03305f105c1518120b650f3d32701e2a183de7a01637f1f478fce9332b25
       flags: 0
-    RecentlyUsedScenePath-7:
-      value: 224247031146467e1e0d03305f105c1518120b65212d28251220133ae1e93534acf238e0f323
+    RecentlyUsedScenePath-6:
+      value: 224247031146467e1e0d03305f105c1518120b650d2a2322393c0f32cbee3d3bebe63aa7f234362820
       flags: 0
-    RecentlyUsedScenePath-8:
+    RecentlyUsedScenePath-7:
       value: 224247031146467e1e0d03305f105c1518120b65180d1504081a5326ece92021
       flags: 0
-    RecentlyUsedScenePath-9:
+    RecentlyUsedScenePath-8:
       value: 224247031146467e1e0d03305f105c1518120b650b292b35012c0b36eeae2136ebf32f
+      flags: 0
+    RecentlyUsedScenePath-9:
+      value: 224247031146467e1e0d03305f105c1518120b65212d28251220133ae1e93534acf238e0f323
       flags: 0
   m_VCAutomaticAdd: 1
   m_VCDebugCom: 0


### PR DESCRIPTION
Da forma que estava, ao parar o player (desligar os controles de movimentação), a troca de animação também parava, por exemplo, se o player estivesse caindo e entrasse em uma cutscene, ao tocar o chão a animação não continuava, ficava sempre naquele mesmo até terminar a curscene, foi isso que eu corrigi